### PR TITLE
Refactor

### DIFF
--- a/scripts/monitor-session-activity.sh
+++ b/scripts/monitor-session-activity.sh
@@ -1,12 +1,13 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -eu
 
-POLL_INTERVAL=10 # seconds
-
-BUCKET_ID="aw-watcher-tmux"
-HOST="localhost"
-PORT="5600"
-API_URL="http://$HOST:$PORT/api"
-PULSETIME="120.0"
+readonly DEBUG=0
+readonly POLL_INTERVAL=10 # seconds
+readonly BUCKET_ID="aw-watcher-tmux"
+readonly HOST="localhost"
+readonly PORT="5600"
+readonly API_URL="http://$HOST:$PORT/api"
+readonly PULSETIME="120.0"
 
 ######
 # Related documentation:
@@ -15,40 +16,38 @@ PULSETIME="120.0"
 #
 #
 
+TMP_FILE=$(mktemp "${TMP:-/tmp}/${BUCKET_ID}.XXXXXX")
+
+if (($DEBUG)); then
+  echo "$TMP_FILE" 
+  set -x 
+  exec 1>>"$TMP_FILE"
+  exec 2>&1
+fi
 
 ### FUNCTIONS
 
-DEBUG=0
-TMP_FILE=$(mktemp)
-echo $TMP_FILE
-
 init_bucket() {
-    HTTP_CODE=$(curl -X GET "${API_URL}/0/buckets/$BUCKET_ID" -H "accept: application/json" -s -o /dev/null -w %{http_code})
-    if (( $HTTP_CODE == 404 )) # not found
-    then
+    HTTP_CODE=$(curl -X GET "${API_URL}/0/buckets/$BUCKET_ID" -H "accept: application/json" -s -o /dev/null -w '%{http_code}')
+    if (( $HTTP_CODE == 404 )); then  # not found
         JSON="{\"client\":\"$BUCKET_ID\",\"type\":\"tmux.sessions\",\"hostname\":\"$(hostname)\"}"
-        HTTP_CODE=$(curl -X POST "${API_URL}/0/buckets/$BUCKET_ID" -H "accept: application/json" -H "Content-Type: application/json" -d "$JSON"  -s -o /dev/null -w %{http_code})
-        if (( $HTTP_CODE != 200 ))
-        then
-            echo "ERROR creating bucket"
-            exit -1
+        HTTP_CODE=$(curl -X POST "${API_URL}/0/buckets/$BUCKET_ID" -H "accept: application/json" -H "Content-Type: application/json" -d "$JSON"  -s -o /dev/null -w '%{http_code}')
+        if (( $HTTP_CODE != 200 )); then
+            echo "ERROR creating bucket" >&2
+            exit 1
         fi
     fi
 }
 
 log_to_bucket() {
-    sess=$1
-    DATA=$(tmux display -t $sess -p "{\"title\":\"#{session_name}\",\"session_name\":\"#{session_name}\",\"window_name\":\"#{window_name}\",\"pane_title\":\"#{pane_title}\",\"pane_current_command\":\"#{pane_current_command}\",\"pane_current_path\":\"#{pane_current_path}\"}");
+    session=$1
+    DATA=$(tmux display -t "$session" -p "{\"title\":\"#{session_name}\",\"session_name\":\"#{session_name}\",\"window_name\":\"#{window_name}\",\"pane_title\":\"#{pane_title}\",\"pane_current_command\":\"#{pane_current_command}\",\"pane_current_path\":\"#{pane_current_path}\"}");
     PAYLOAD="{\"timestamp\":\"$(date -Is)\",\"duration\":0,\"data\":$DATA}"
-    echo "$PAYLOAD"
-    HTTP_CODE=$(curl -X POST "${API_URL}/0/buckets/$BUCKET_ID/heartbeat?pulsetime=$PULSETIME" -H "accept: application/json" -H "Content-Type: application/json" -d "$PAYLOAD" -s -o $TMP_FILE -w %{http_code})
+    (($DEBUG)) && echo "$PAYLOAD" >&2
+    HTTP_CODE=$(curl -X POST "${API_URL}/0/buckets/$BUCKET_ID/heartbeat?pulsetime=$PULSETIME" -H "accept: application/json" -H "Content-Type: application/json" -d "$PAYLOAD" -s -o "$TMP_FILE" -w '%{http_code}')
     if (( $HTTP_CODE != 200 )); then
-        echo "Request failed"
-        cat $TMP_FILE
-    fi
-
-    if [[ "$DEBUG" -eq "1" ]]; then
-        cat $TMP_FILE
+        echo "Request failed - $HTTP_CODE" >&2
+        return 1
     fi
 }
 
@@ -59,37 +58,36 @@ declare -A act_last
 declare -A act_current
 
 init_bucket
+OLDIFS=$IFS
 
-while [ true ]
-do
-    #clear
-	sessions=$(tmux list-sessions | awk '{print $1}')
-	if (( $? != 0 )); then
-        echo "tmux list-sessions ERROR: $?"
+while :; do
+    if ! sessions=$(tmux list-sessions -F '#{session_name}'); then
+      echo "tmux list-sessions ERROR: $?" >&2
+      exit 1
     fi
-	if (( $? == 0 )); then
-        LAST_IFS=$IFS
-        IFS='
-'   
-        for sess in ${sessions}; do
-            act_time=$(tmux display -t $sess -p '#{session_activity}')
-            if [[ ! -v "act_last[$sess]" ]];  then
-                act_last[$sess]='0'
-            fi
-            if (( $act_time > ${act_last[$sess]} )); then
-                # echo "###> "$sess' '$(date -Iseconds)'    '$act_time' '$act_last[$sess] ##  >> tmux-sess-act.log
-                log_to_bucket $sess
-            fi
-            act_current[$sess]=$act_time 
-        done
-        IFS=$LAST_IFS
-        # copy arrays
-        unset R
-        declare -A act_last
-        for sess in "${!act_current[@]}"; do
-            act_last[$sess]=${act_current[$sess]}
-        done
-	fi
-	
-	sleep $POLL_INTERVAL
+    if [[ -z "$sessions" ]]; then
+      echo "sessions empty" >&2
+      continue
+    fi
+
+    IFS=$'\n'
+    for session in ${sessions}; do
+        act_time=$(tmux display -t "$session" -p '#{session_activity}')
+        if [[ ! -v "act_last[$session]" ]]; then
+            act_last[$session]='0'
+        fi
+        if (( $act_time > ${act_last[$session]} )); then
+            # echo "###> "$session' '$(date -Iseconds)'    '$act_time' '$act_last[$session] ##  >> tmux-session-act.log
+            log_to_bucket "$session"
+        fi
+        act_current[$session]=$act_time 
+    done
+    IFS=$OLDIFS
+    # copy arrays
+    declare -A act_last
+    for session in "${!act_current[@]}"; do
+        act_last[$session]=${act_current[$session]}
+    done
+    
+    sleep $POLL_INTERVAL
 done


### PR DESCRIPTION
The plugin crashed tmux for me when session names had spaces

* fix session name quoting for long strings including spaces
* exit plugin if no sessions are running
* echo to stderr
* debug to named tmpfile
* renamed sess variable to session
* set static variables to readonly
* set bash options to exit on error or undefined variables